### PR TITLE
Implement choosing from favourite routes when ordering (closes #51)

### DIFF
--- a/frontend/Gorki/src/app/favourite-route-card/favourite-route-card.css
+++ b/frontend/Gorki/src/app/favourite-route-card/favourite-route-card.css
@@ -1,0 +1,62 @@
+.ride-card {
+  width: 305px;
+  height: 420px;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  transition: 
+    transform 0.25s ease,
+    box-shadow 0.25s ease;
+}
+
+.ride-card:hover{
+  transform: translateY(-6px);
+  box-shadow: 0 16px 35px rgba(0, 0, 0, 0.25);
+}
+
+h1 {
+  margin: 0;
+  font-size: 26px;
+  font-weight: bolder;
+  font-family: 'Sofia Sans Condensed';
+}
+
+hr {
+  border: none;
+  border-top: 1px solid #e5e5e5;
+  margin: 2px 0 2px;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 13px;
+}
+
+li {
+  margin-bottom: 8px;
+  font-size: 17px;
+  font-family: 'Sofia Sans Condensed';
+}
+
+strong{
+  font-weight: bolder;
+}
+
+.more-info {
+  margin-top: 14px;
+  padding: 10px;
+  border-radius: 20px;
+  border: none;
+  background: #3c2f8f;
+  color: white;
+  font-weight: bold;
+  cursor: pointer;
+  font-family: 'Sofia Sans Condensed';
+}

--- a/frontend/Gorki/src/app/favourite-route-card/favourite-route-card.html
+++ b/frontend/Gorki/src/app/favourite-route-card/favourite-route-card.html
@@ -1,0 +1,28 @@
+<div class="ride-card">
+  <h1>Route No. {{ route.id }}</h1>
+  <hr/>
+  <ul>
+    <li>
+      <strong>Starting point</strong> -
+      {{ route.startingPoint }}
+    </li>
+    <li>
+      <strong>Destination</strong> -
+      {{ route.destination }}
+    </li>
+  </ul>
+  <hr />
+  <ul>
+    <li>
+        <strong>Stopping points:</strong>
+        <ul>
+            @for(point of route.stoppingPoints; track point){
+                <li>- {{point}}</li>
+            }
+        </ul>
+    </li>
+  </ul>
+  <button class="more-info" type="button" routerLink="/home">
+    CHOOSE   
+  </button>
+</div>

--- a/frontend/Gorki/src/app/favourite-route-card/favourite-route-card.spec.ts
+++ b/frontend/Gorki/src/app/favourite-route-card/favourite-route-card.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FavouriteRouteCard } from './favourite-route-card';
+
+describe('FavouriteRouteCard', () => {
+  let component: FavouriteRouteCard;
+  let fixture: ComponentFixture<FavouriteRouteCard>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FavouriteRouteCard]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(FavouriteRouteCard);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/Gorki/src/app/favourite-route-card/favourite-route-card.ts
+++ b/frontend/Gorki/src/app/favourite-route-card/favourite-route-card.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Route } from '../model/ui/route';
+import { RouterLink } from "@angular/router";
+
+@Component({
+  selector: 'app-favourite-route-card',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './favourite-route-card.html',
+  styleUrl: './favourite-route-card.css',
+})
+export class FavouriteRouteCard {
+  @Input() route!: Route;
+}

--- a/frontend/Gorki/src/app/favourite-routes/favourite-routes.css
+++ b/frontend/Gorki/src/app/favourite-routes/favourite-routes.css
@@ -1,0 +1,75 @@
+.divider{
+    background-color: #ffffff;
+    color:#ffffff;
+}
+.carousel-wrapper {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.ride-list {
+  display: flex;
+  gap: 32px;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  /*white-space: nowrap;*/
+  background: transparent;
+  padding: 20px;
+  max-width: 100%;
+}
+
+/* sakrij scrollbar */
+.ride-list::-webkit-scrollbar {
+  display: none;
+  background: transparent;
+}
+
+/* kartice se NE SMEJU skupljati */
+app-favourite-route-card {
+  flex: 0 0 auto;
+}
+
+/* strelice */
+.nav {
+  background: #3c2f8f;
+  color: white;
+  border: none;
+  border-radius: 50%;
+  min-width: 44px;
+  min-height: 44px;
+  font-size: 26px;
+  cursor: pointer;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.nav.left {
+  margin-right: 12px;
+}
+
+.nav.right {
+  margin-left: 12px;
+}
+
+.no-favourite-routes{
+    width: 500px;
+    height: 200px;
+    background-color: white;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    border-radius: 25px;
+    font-family: 'Sofia Sans Condensed';
+    font-size: 32px;
+    font-weight: bold;
+    color: #362D88;
+    align-content: center;
+    text-align: center;
+}

--- a/frontend/Gorki/src/app/favourite-routes/favourite-routes.html
+++ b/frontend/Gorki/src/app/favourite-routes/favourite-routes.html
@@ -1,0 +1,16 @@
+@if (routes.length === 0) {
+        <div class="no-favourite-routes">
+            There are no favourite routes
+        </div>
+} @else {
+<div class="carousel-wrapper">
+  <button class="nav left" (click)="scrollLeft()">‹</button>
+
+  <div class="ride-list" #carousel>
+    @for(route of routes; track route){
+        <app-favourite-route-card [route]="route"></app-favourite-route-card>
+    }
+  </div>
+  <button class="nav right" (click)="scrollRight()">›</button>
+</div>
+}

--- a/frontend/Gorki/src/app/favourite-routes/favourite-routes.spec.ts
+++ b/frontend/Gorki/src/app/favourite-routes/favourite-routes.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FavouriteRoutes } from './favourite-routes';
+
+describe('FavouriteRoutes', () => {
+  let component: FavouriteRoutes;
+  let fixture: ComponentFixture<FavouriteRoutes>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FavouriteRoutes]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(FavouriteRoutes);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/Gorki/src/app/favourite-routes/favourite-routes.ts
+++ b/frontend/Gorki/src/app/favourite-routes/favourite-routes.ts
@@ -1,0 +1,56 @@
+import { Component, ViewChild, ElementRef } from '@angular/core';
+import { FavouriteRouteCard } from '../favourite-route-card/favourite-route-card';
+import { Route } from '../model/ui/route';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-favourite-routes',
+  imports: [FavouriteRouteCard],
+  templateUrl: './favourite-routes.html',
+  styleUrl: './favourite-routes.css',
+})
+export class FavouriteRoutes {
+  @ViewChild('carousel', { static: true })
+  carousel!: ElementRef<HTMLDivElement>;
+
+  scrollLeft() {
+    this.carousel.nativeElement.scrollBy({
+      left: -300,
+      behavior: 'smooth',
+    });
+  }
+
+  scrollRight() {
+    this.carousel.nativeElement.scrollBy({
+      left: 300,
+      behavior: 'smooth',
+    });
+  }
+
+  routes:Route[] = [
+    {
+      id: 1,
+      startingPoint: 'Miše Dimitrijevića 5, Grbavica',
+      stoppingPoints: [
+        'Ive Andrica 15, Liman 4',
+      ],
+      destination: 'Jerneja Kopitara 32, Telep'
+    },
+    {
+      id: 2,
+      startingPoint: 'Miše Dimitrijevića 5, Grbavica',
+      stoppingPoints: [
+        'Ive Andrica 15, Liman 4',
+      ],
+      destination: 'Jerneja Kopitara 32, Telep'
+    },
+    {
+      id: 3,
+      startingPoint: 'Miše Dimitrijevića 5, Grbavica',
+      stoppingPoints: [
+        'Ive Andrica 15, Liman 4',
+      ],
+      destination: 'Jerneja Kopitara 32, Telep'
+    },
+  ];
+}


### PR DESCRIPTION
This PR adds support for selecting favorite routes during the ride ordering process.

Favorite routes list available on the ride ordering page.
Quick route selection that automatically fills:
- Starting point
- Destination
- Intermediate stops (in correct order)

Closes #51