### PR TITLE
Refactor: Add annotations for entities and properties for database (closes #63)

### DIFF
--- a/backend/Projekatsiit2025/pom.xml
+++ b/backend/Projekatsiit2025/pom.xml
@@ -40,6 +40,15 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/Projekatsiit2025Application.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/Projekatsiit2025Application.java
@@ -2,11 +2,35 @@ package rs.ac.uns.ftn.asd.Projekatsiit2025;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-@SpringBootApplication
+
+@SpringBootApplication(scanBasePackages = "rs.ac.uns.ftn.asd.Projekatsiit2025")
+@EntityScan("rs.ac.uns.ftn.asd.Projekatsiit2025.model")
+@EnableJpaRepositories("rs.ac.uns.ftn.asd.Projekatsiit2025.repository")
 public class Projekatsiit2025Application {
 
 	public static void main(String[] args) {
 		SpringApplication.run(Projekatsiit2025Application.class, args);
+	
+		/*
+		 * Ako u application.properties stoji:
+		 * 1. spring.jpa.hibernate.ddl-auto=create --> svkai put kada se
+		 * aplikacija pokrene, tabele se automatski brisu i ponovo prave
+		 * 2. spring.jpa.hibernate.ddl-auto=update --> tabele su napravljenej pri
+		 * prvom pokretanju, i samo se azuriraju pri svakom novom
+		 * 
+		 * TRENUTNO SE KORISTI UPDATE. MOZE TAKO DA OSTANE
+		 * 
+		 * U SRC/MAIN/RESOURCES SE NALAZI FAJL import.sql
+		 * U njega se pisu sve insert naredbe, i pri pokretanju aplikacije
+		 * tabele se na osnovu njega azuriraju/pune/prazne
+		 * 
+		 * */
+		System.out.println("==========================");
+		System.out.println("    STARTED SUCESSFULLY   ");
+		System.out.println("==========================\n");
+		
 	}
 }

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/controller/DriverController.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/controller/DriverController.java
@@ -22,6 +22,7 @@ import rs.ac.uns.ftn.asd.Projekatsiit2025.dto.UpdateVehicleDTO;
 import rs.ac.uns.ftn.asd.Projekatsiit2025.dto.UpdatedVehicleDTO;
 import rs.ac.uns.ftn.asd.Projekatsiit2025.model.enums.UserRole;
 import rs.ac.uns.ftn.asd.Projekatsiit2025.model.enums.VehicleType;
+import rs.ac.uns.ftn.asd.Projekatsiit2025.service.RideService;
 import rs.ac.uns.ftn.asd.Projekatsiit2025.model.Location;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -29,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -40,6 +42,11 @@ import rs.ac.uns.ftn.asd.Projekatsiit2025.model.Route;
 @RequestMapping("/api/drivers")
 public class DriverController {
 	
+	//RideService
+    private final RideService rideService;
+    public DriverController(RideService rideService) {
+        this.rideService = rideService;
+    }
 	@PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<CreatedDriverDTO> createDriver(@RequestBody CreateDriverDTO requestDriver){
 		CreatedDriverDTO responseDriver = new CreatedDriverDTO();
@@ -107,39 +114,8 @@ public class DriverController {
 	        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
 	        LocalDate to) {
 
-	    Collection<DriverRideHistoryDTO> rides = new ArrayList<>();
-
-	    // ---- PUTNICI ZA PRVU VOZNJU ----
-	    List<PassengerInRideDTO> passengers1 = new ArrayList<>();
-	    PassengerInRideDTO p1 = new PassengerInRideDTO();
-	    p1.setEmail("petar.petrovic@gmail.com");
-	    p1.setFirstName("Petar");
-	    p1.setLastName("Petrovic");
-	    p1.setPhoneNumber("+38164859612");
-	    PassengerInRideDTO p2 = new PassengerInRideDTO();
-	    p2.setEmail("ana.anic@gmail.com");
-	    p2.setFirstName("Ana");
-	    p2.setLastName("Anic");
-	    p2.setPhoneNumber("+38160456728");
-	    passengers1.add(p1);
-	    passengers1.add(p2);
-	    List<Location> locations = new ArrayList<>();
-	    locations.add(new Location(45.2671, 19.8335, "Trg slobode 1, Novi Sad"));
-	    locations.add(new Location(45.2567, 19.8452, "Bulevar oslobođenja 45, Novi Sad"));
-	    
-	    // ---- PRVA VOZNJA ----
-	    DriverRideHistoryDTO ride1 = new DriverRideHistoryDTO();
-	    ride1.setRideId(1L);
-	    ride1.setStartingTime(LocalDateTime.of(2025, 1, 10, 14, 30));
-	    ride1.setEndingTime(LocalDateTime.of(2025, 1, 10, 15, 0));
-	    ride1.setRoute(new Route(1L,locations,3.7,LocalDateTime.of(2025, 1, 10, 14, 55)));
-	    ride1.setCanceled(false);
-	    ride1.setCanceledBy(null);
-	    ride1.setPrice(850.00);
-	    ride1.setPanicActivated(false);
-	    ride1.setPassengers(passengers1);
-
-	    rides.add(ride1);
-	    return new ResponseEntity<>(rides, HttpStatus.OK);
+		 return ResponseEntity.ok(
+		            rideService.getDriverRideHistory(driverId, from, to)
+		    );
 	}
 }

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/dto/DriverRideHistoryDTO.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/dto/DriverRideHistoryDTO.java
@@ -10,7 +10,7 @@ public class DriverRideHistoryDTO {
 	private Long rideId;
     private LocalDateTime startingTime;
     private LocalDateTime endingTime;
-    private Route route;
+    private GetRouteDTO route;
     private boolean canceled;
     private String canceledBy; 
     private double price;
@@ -38,10 +38,10 @@ public class DriverRideHistoryDTO {
 	public void setEndingTime(LocalDateTime endingTime) {
 		this.endingTime = endingTime;
 	}
-	public Route getRoute() {
+	public GetRouteDTO getRoute() {
 		return route;
 	}
-	public void setRoute(Route route) {
+	public void setRoute(GetRouteDTO route) {
 		this.route = route;
 	}
 	public boolean isCanceled() {

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/dto/PassengerInRideDTO.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/dto/PassengerInRideDTO.java
@@ -10,6 +10,13 @@ public class PassengerInRideDTO {
 	 	private String firstName;
 	 	private String lastName;
 	 	private String phoneNumber;
+		public PassengerInRideDTO(String email, String firstName, String lastName, String phoneNumber) {
+			super();
+			this.email = email;
+			this.firstName = firstName;
+			this.lastName = lastName;
+			this.phoneNumber = phoneNumber;
+		}
 		public PassengerInRideDTO() {
 			super();
 		}

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Admin.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Admin.java
@@ -1,5 +1,8 @@
 package rs.ac.uns.ftn.asd.Projekatsiit2025.model;
 
+import jakarta.persistence.Entity;
+
+@Entity
 public class Admin extends User {
 	
 	public Admin() {

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Chat.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Chat.java
@@ -2,11 +2,27 @@ package rs.ac.uns.ftn.asd.Projekatsiit2025.model;
 
 import java.util.List;
 
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+@Entity
 public class Chat {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-	private List<Message>messages;
-	private Passenger passenger;
-	private Admin admin;
+    
+    @ElementCollection
+    private List<Message> messages;
+
+    @ManyToOne
+    private Passenger passenger;
+
+    @ManyToOne
+    private Admin admin;
 	
 	public Chat() {
 	}

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Driver.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Driver.java
@@ -1,11 +1,22 @@
 package rs.ac.uns.ftn.asd.Projekatsiit2025.model;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import rs.ac.uns.ftn.asd.Projekatsiit2025.model.enums.DriverStatus;
 
+@Entity
 public class Driver extends User {
 	
-	private Vehicle vehicle;
-	private DriverStatus status;
+	@OneToOne
+    @JoinColumn(name = "vehicle_id")
+    private Vehicle vehicle;
+
+    @Enumerated(EnumType.STRING)
+    private DriverStatus status;
+    
 	private double activityLast24h;
 	
 	public Driver() {

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/IncosistencyReport.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/IncosistencyReport.java
@@ -2,11 +2,28 @@ package rs.ac.uns.ftn.asd.Projekatsiit2025.model;
 
 import java.time.LocalDateTime;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
 public class IncosistencyReport {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+    
 	private String description;
 	private LocalDateTime timeStamp;
+	
+	@ManyToOne
+    @JoinColumn(name = "passenger_id")
 	private Passenger passenger;
+	
+	@ManyToOne
+	@JoinColumn(name = "ride_id")
 	private Ride ride;
 	
 	public IncosistencyReport() {

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Location.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Location.java
@@ -1,5 +1,9 @@
 package rs.ac.uns.ftn.asd.Projekatsiit2025.model;
 
+import jakarta.persistence.Embeddable;
+
+
+@Embeddable
 public class Location {
 		private double latitude;
 		private double longitude;

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Message.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Message.java
@@ -2,6 +2,9 @@ package rs.ac.uns.ftn.asd.Projekatsiit2025.model;
 
 import java.time.LocalDateTime;
 
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+@Embeddable
 public class Message {
 	private String sender;
 	private String content;

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Notification.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Notification.java
@@ -2,12 +2,25 @@ package rs.ac.uns.ftn.asd.Projekatsiit2025.model;
 
 import java.time.LocalDateTime;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+@Entity
 public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+    
 	private String purpose;
 	private String content;
 	private LocalDateTime createdAt;
 	private Boolean read = false;
+	
+	@ManyToOne
+	@JoinColumn(name = "user_id")
 	private User user;
 	
 	public Notification() {

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/PanicEvent.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/PanicEvent.java
@@ -2,12 +2,28 @@ package rs.ac.uns.ftn.asd.Projekatsiit2025.model;
 
 import java.time.LocalDateTime;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+@Entity
 public class PanicEvent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	private LocalDateTime timeStamp;
 	private Boolean resolved=false;
+	
+	@ManyToOne
+	@JoinColumn(name = "user_id")
 	private User user;
+	
+	@ManyToOne
+	@JoinColumn(name = "ride_id")
 	private Ride ride;
+	
 	public PanicEvent() {
 	}
 	public PanicEvent(Long id, LocalDateTime timeStamp, Boolean resolved, User user, Ride ride) {

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Passenger.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Passenger.java
@@ -2,7 +2,14 @@ package rs.ac.uns.ftn.asd.Projekatsiit2025.model;
 
 import java.util.List;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+
+@Entity
 public class Passenger extends User {
+	@ManyToMany
 	private List<Route> favouriteRoutes;
 
 	public Passenger() {

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/PriceConfig.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/PriceConfig.java
@@ -1,5 +1,8 @@
 package rs.ac.uns.ftn.asd.Projekatsiit2025.model;
 
+import jakarta.persistence.Embeddable;
+
+@Embeddable
 public class PriceConfig {
 	private double priceByVehicleType;
 	private double pricePerKm;

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Rating.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Rating.java
@@ -2,12 +2,25 @@ package rs.ac.uns.ftn.asd.Projekatsiit2025.model;
 
 import java.time.LocalDateTime;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+@Entity
 public class Rating {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+    
 	private double driverRating;
 	private double vehicleRating;
 	private String comment;
 	private LocalDateTime createdAt;
+	
+	@ManyToOne
+	@JoinColumn(name = "ride_id")
 	private Ride ride;
 	
 	public Rating() {

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Ride.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Ride.java
@@ -3,11 +3,30 @@ package rs.ac.uns.ftn.asd.Projekatsiit2025.model;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import rs.ac.uns.ftn.asd.Projekatsiit2025.model.enums.RideStatus;
 
+@Entity
 public class Ride {
+	
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+    
+    @Enumerated(EnumType.STRING)
 	private RideStatus status;
+	
 	private double price;
 	private LocalDateTime scheduledTime;
 	private LocalDateTime startingTime;
@@ -15,10 +34,28 @@ public class Ride {
 	private Boolean panicActivated;
 	private String cancellationReason;
 	private String cancelledBy;
+	
+	@ManyToOne
+	@JoinColumn(name = "driver_id")
 	private Driver driver;
+	
+	@ManyToOne
+	@JoinColumn(name = "route_id")
 	private Route route;
+	
+	@Embedded
 	private PriceConfig priceConfig;
+	
+	@ManyToMany
+	@JoinTable(
+	    name = "ride_passengers",
+	    joinColumns = @JoinColumn(name = "ride_id"),
+	    inverseJoinColumns = @JoinColumn(name = "passenger_id")
+	)
 	private List<Passenger> linkedPassengers;
+	
+	@ManyToOne
+	@JoinColumn(name = "creator_id")
 	private Passenger creator;
 	
 	public Ride() {

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Route.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Route.java
@@ -1,10 +1,24 @@
 package rs.ac.uns.ftn.asd.Projekatsiit2025.model;
 
 import java.time.LocalDateTime;
+
 import java.util.List;
 
+import org.hibernate.annotations.ManyToAny;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+
+@Entity
 public class Route {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+    @ElementCollection
 	private List<Location> locations;
 	private double distance;
 	private LocalDateTime estimatedTime;

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/User.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/User.java
@@ -1,9 +1,22 @@
 package rs.ac.uns.ftn.asd.Projekatsiit2025.model;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
 import rs.ac.uns.ftn.asd.Projekatsiit2025.model.enums.UserRole;
 
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED) //SINGLE_TABLE
+@Table(name = "\"user\"")
 public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+    
 	private String email;
 	private String password;
 	private String firstName;

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Vehicle.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/model/Vehicle.java
@@ -1,11 +1,25 @@
 package rs.ac.uns.ftn.asd.Projekatsiit2025.model;
 
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import rs.ac.uns.ftn.asd.Projekatsiit2025.model.enums.VehicleType;
-
+@Entity
 public class Vehicle {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+    
+    @Embedded
 	private Location currentLocation;
+    
 	private String model;
+	@Enumerated(EnumType.STRING)
+	
 	private VehicleType type;
 	private String plateNumber;
 	private int seats;

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/repository/RideRepository.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/repository/RideRepository.java
@@ -1,0 +1,21 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2025.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import rs.ac.uns.ftn.asd.Projekatsiit2025.model.Ride;
+
+@Repository
+public interface RideRepository extends JpaRepository<Ride, Long> {
+	
+    List<Ride> findByDriverIdAndStartingTimeBetween(
+            @Param("driverId") Long driverId,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to
+    );
+
+}

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/repository/package-info.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/repository/package-info.java
@@ -1,0 +1,1 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2025.repository;

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/service/RideService.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/service/RideService.java
@@ -1,0 +1,83 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2025.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import rs.ac.uns.ftn.asd.Projekatsiit2025.dto.DriverRideHistoryDTO;
+import rs.ac.uns.ftn.asd.Projekatsiit2025.dto.GetRouteDTO;
+import rs.ac.uns.ftn.asd.Projekatsiit2025.dto.LocationDTO;
+import rs.ac.uns.ftn.asd.Projekatsiit2025.dto.PassengerInRideDTO;
+import rs.ac.uns.ftn.asd.Projekatsiit2025.model.Ride;
+import rs.ac.uns.ftn.asd.Projekatsiit2025.model.Route;
+import rs.ac.uns.ftn.asd.Projekatsiit2025.model.enums.RideStatus;
+import rs.ac.uns.ftn.asd.Projekatsiit2025.repository.RideRepository;
+
+@Service
+public class RideService {
+    private final RideRepository rideRepository;
+
+    public RideService(RideRepository rideRepository) {
+        this.rideRepository = rideRepository;
+    }
+    
+    @Transactional(readOnly = true)
+    public Collection<DriverRideHistoryDTO> getDriverRideHistory(
+            Long driverId,
+            LocalDate from,
+            LocalDate to) {
+
+        LocalDateTime fromDateTime = (from != null)
+                ? from.atStartOfDay()
+                : LocalDate.of(2000, 1, 1).atStartOfDay();  // SAFE MIN
+
+        LocalDateTime toDateTime = (to != null)
+                ? to.atTime(23, 59, 59)
+                : LocalDate.of(2100, 1, 1).atStartOfDay();  // SAFE MAX
+
+        List<Ride> rides = rideRepository
+                .findByDriverIdAndStartingTimeBetween(driverId, fromDateTime, toDateTime);
+
+        return rides.stream().map(this::mapToDTO).toList();
+    }
+
+    private DriverRideHistoryDTO mapToDTO(Ride ride) {
+        DriverRideHistoryDTO dto = new DriverRideHistoryDTO();
+        dto.setRideId(ride.getId());
+        dto.setStartingTime(ride.getStartingTime());
+        dto.setEndingTime(ride.getEndingTime());
+        dto.setPrice(ride.getPrice());
+        dto.setPanicActivated(ride.getPanicActivated());
+        dto.setCanceled(ride.getStatus() == RideStatus.CANCELED);
+        dto.setCanceledBy(ride.getCancelledBy());
+        dto.setPassengers(ride.getLinkedPassengers()
+                .stream()
+                .map(p -> new PassengerInRideDTO(
+                        p.getEmail(),
+                        p.getFirstName(),
+                        p.getLastName(),
+                        String.valueOf(p.getPhoneNumber())
+                ))
+                .toList()
+        );
+        Route route = ride.getRoute();
+        GetRouteDTO routeDTO = new GetRouteDTO(
+        	    route.getId(),
+        	    route.getLocations().stream()
+        	         .map((rs.ac.uns.ftn.asd.Projekatsiit2025.model.Location loc) -> 
+        	             new LocationDTO(loc.getLatitude(), loc.getLongitude(),"Neka adresa"))
+        	         .toList(),
+        	    route.getDistance(),
+        	    route.getEstimatedTime()
+		);
+        dto.setRoute(routeDTO);
+        return dto;
+    }
+    
+    
+}

--- a/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/service/package-info.java
+++ b/backend/Projekatsiit2025/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2025/service/package-info.java
@@ -1,0 +1,1 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2025.service;

--- a/backend/Projekatsiit2025/src/main/resources/application.properties
+++ b/backend/Projekatsiit2025/src/main/resources/application.properties
@@ -1,1 +1,10 @@
 spring.application.name=Projekatsiit2025
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/mrsTeamGorki
+spring.datasource.username=gorki_team
+spring.datasource.password=gorki123
+
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.open-in-view=false

--- a/backend/Projekatsiit2025/src/main/resources/import.sql
+++ b/backend/Projekatsiit2025/src/main/resources/import.sql
@@ -1,0 +1,160 @@
+-- ČIST START
+-- =======================
+-- KORISNICI I VOZAČI / PUTNICI
+-- =======================
+-- Prvi vozač
+INSERT INTO "user" (
+    id, email, password, first_name, last_name,
+    phone_number, address, profile_image,
+    active, blocked, role
+) VALUES (
+    1,
+    'driver1@gmail.com',
+    'pass',
+    'Marko',
+    'Markovic',
+    611111111,
+    'Novi Sad',
+    NULL,
+    true,
+    false,
+    1
+);
+
+-- Prva putnica
+INSERT INTO "user" (
+    id, email, password, first_name, last_name,
+    phone_number, address, profile_image,
+    active, blocked, role
+) VALUES (
+    2,
+    'passenger1@gmail.com',
+    'pass',
+    'Ana',
+    'Anic',
+    622222222,
+    'Novi Sad',
+    NULL,
+    true,
+    false,
+    0
+);
+
+-- Drugi vozač
+INSERT INTO "user" (
+    id, email, password, first_name, last_name,
+    phone_number, address, profile_image,
+    active, blocked, role
+) VALUES (
+    3,
+    'driver2@gmail.com',
+    'pass',
+    'Jovan',
+    'Jovic',
+    633333333,
+    'Novi Sad',
+    NULL,
+    true,
+    false,
+    1
+);
+
+-- Druga putnica
+INSERT INTO "user" (
+    id, email, password, first_name, last_name,
+    phone_number, address, profile_image,
+    active, blocked, role
+) VALUES (
+    4,
+    'passenger2@gmail.com',
+    'pass',
+    'Maja',
+    'Majic',
+    644444444,
+    'Novi Sad',
+    NULL,
+    true,
+    false,
+    0
+);
+
+-- =======================
+-- DRIVER & PASSENGER
+-- =======================
+
+INSERT INTO driver (id, vehicle_id, status, activity_last24h) VALUES
+(1, NULL, 'ACTIVE', 5.5),
+(3, NULL, 'ACTIVE', 4.2);
+
+INSERT INTO passenger (id) VALUES
+(2),
+(4);
+
+-- =======================
+-- RUTE
+-- =======================
+
+INSERT INTO route (id, distance) VALUES
+(1, 5.2),
+(2, 8.0),
+(3, 12.5);
+
+-- =======================
+-- VOŽNJE
+-- =======================
+
+-- Vožnja 1: driver1 i passenger1
+INSERT INTO ride (
+    id, status, price, scheduled_time, starting_time, ending_time,
+    panic_activated, cancellation_reason, cancelled_by,
+    driver_id, route_id, creator_id
+) VALUES (
+    1, 'FINISHED', 750.0, '2025-01-20 09:50:00', '2025-01-20 10:00:00', '2025-01-20 10:25:00',
+    false, NULL, NULL,
+    1, 1, 2
+);
+
+-- Vožnja 2: driver2 i passenger2
+INSERT INTO ride (
+    id, status, price, scheduled_time, starting_time, ending_time,
+    panic_activated, cancellation_reason, cancelled_by,
+    driver_id, route_id, creator_id
+) VALUES (
+    2, 'FINISHED', 1200.0, '2025-01-21 14:00:00', '2025-01-21 14:10:00', '2025-01-21 14:50:00',
+    false, NULL, NULL,
+    3, 2, 4
+);
+
+-- Vožnja 3: driver1 i oba putnika
+INSERT INTO ride (
+    id, status, price, scheduled_time, starting_time, ending_time,
+    panic_activated, cancellation_reason, cancelled_by,
+    driver_id, route_id, creator_id
+) VALUES (
+    3, 'FINISHED', 900.0, '2025-01-22 09:00:00', '2025-01-22 09:15:00', '2025-01-22 09:45:00',
+    false, NULL, NULL,
+    1, 3, 2
+);
+
+-- Vožnja 4: driver2 i oba putnika
+INSERT INTO ride (
+    id, status, price, scheduled_time, starting_time, ending_time,
+    panic_activated, cancellation_reason, cancelled_by,
+    driver_id, route_id, creator_id
+) VALUES (
+    4, 'FINISHED', 1500.0, '2025-01-23 11:00:00', '2025-01-23 11:05:00', '2025-01-23 11:50:00',
+    false, NULL, NULL,
+    3, 3, 4
+);
+
+-- =======================
+-- VOŽNJE - PASSENGERI
+-- =======================
+
+INSERT INTO ride_passengers (ride_id, passenger_id) VALUES
+(1, 2),
+(2, 4),
+(3, 2),
+(3, 4),
+(4, 2),
+(4, 4);


### PR DESCRIPTION
Refactoring the backend entities by:

- Adding appropriate JPA annotations for entity mapping.
- Correctly annotating id fields and inheritance where applicable.
- Defining proper relationships and cardinalities for non-primitive types (@ManyToOne, @OneToMany, etc.).
- Organizing service and repository packages for better modularity and maintainability.

Closes #63 