### PR TITLE
Add notification inbox for all notifications in app and integrate with backend (closes #156)

### DIFF
--- a/frontend/Gorki/src/app/layout/navbar/navbar.css
+++ b/frontend/Gorki/src/app/layout/navbar/navbar.css
@@ -213,3 +213,8 @@ a{
     margin-left: 25px;
     margin-top: 9px;
 }
+
+.notifDialog .mat-mdc-dialog-surface {
+  border-radius: 18px !important;
+  overflow: hidden;
+}

--- a/frontend/Gorki/src/app/layout/navbar/navbar.html
+++ b/frontend/Gorki/src/app/layout/navbar/navbar.html
@@ -56,6 +56,10 @@
                 <mat-icon>support_agent</mat-icon>
                 Support
             </div>
+            <div class="notifications" (click)="openNotifications()">
+                <mat-icon>notifications</mat-icon>
+                Notifications
+            </div>
             @if(role == "DRIVER"){
                 <mat-button-toggle-group class="activityLabelGroup" id="activeLabelGroup">
                     <mat-button-toggle style="background-color: green;" class="activityLabelButton" id="activeLabel" [value]="true" 

--- a/frontend/Gorki/src/app/layout/navbar/navbar.ts
+++ b/frontend/Gorki/src/app/layout/navbar/navbar.ts
@@ -16,6 +16,7 @@ import { RatingService } from '../../service/rating-service';
 import { SupportChatService } from '../../service/chat-service';
 import { CreateRatingDto } from '../../model/ui/create-rating-dto';
 import { RatingConfirmPanel } from '../../rides/rating-confirm-panel/rating-confirm-panel';
+import { NotificationInbox } from '../../notification-inbox/notification-inbox';
 
 @Component({
   selector: 'app-navbar',
@@ -155,6 +156,20 @@ export class Navbar implements OnInit, OnDestroy {
       }
     });
   }
+
+  openNotifications(): void {
+    if (!this.isLoggedIn) return;
+
+  this.dialog.open(NotificationInbox, {
+      autoFocus: false,
+      panelClass: 'notifDialog',
+      width: '1000px',
+      maxWidth: '95vw',
+      height: '720px',
+      maxHeight: '90vh',
+    });
+  }
+
 
   private openRatingDialog(rideId: number): void {
     if (this.ratingDialogOpen) return;

--- a/frontend/Gorki/src/app/model/ui/notification-dto.ts
+++ b/frontend/Gorki/src/app/model/ui/notification-dto.ts
@@ -1,0 +1,7 @@
+export interface NotificationDTO {
+  id: number;
+  purpose: string;     // ili type
+  content: string;     // message
+  createdAt: string;   // ISO string
+  read: boolean;
+}

--- a/frontend/Gorki/src/app/notification-inbox/notification-inbox.css
+++ b/frontend/Gorki/src/app/notification-inbox/notification-inbox.css
@@ -1,0 +1,229 @@
+.page{
+  display:flex;
+  height: calc(100vh - 70px); /* prilagodi ako ti navbar ima drugu visinu */
+  background:#fff;
+}
+
+.left{
+  width: 360px;
+  min-width: 320px;
+  border-right: 1px solid rgba(0,0,0,0.08);
+  padding: 18px 16px;
+  display:flex;
+  flex-direction: column;
+  gap: 14px;
+  font-family: 'Sofia Sans Condensed';
+}
+
+.top{
+  display:flex;
+  align-items:center;
+  justify-content: space-between;
+}
+
+.title{
+  display:flex;
+  align-items:center;
+  gap: 10px;
+  font-size: 26px;
+  font-weight: 800;
+  font-family: 'Sofia Sans Condensed';
+}
+
+.titleIcon{
+  font-size: 26px;
+  width: 26px;
+  height: 26px;
+}
+
+.status{
+  display:flex;
+  align-items:center;
+  gap: 8px;
+  font-size: 14px;
+  opacity: .85;
+}
+
+.dot{
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #35c759; /* green */
+}
+
+.refreshBtn{
+  border-radius: 999px !important;
+  height: 44px;
+    font-family: 'Sofia Sans Condensed';
+}
+
+.list{
+  overflow:auto;
+  padding-right: 4px;
+  display:flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.loading{
+  display:flex;
+  align-items:center;
+  gap: 10px;
+      font-family: 'Sofia Sans Condensed';
+  padding: 8px 4px;
+  opacity: .85;
+}
+
+.card{
+  border: 1px solid rgba(0,0,0,0.08);
+  border-radius: 14px;
+  padding: 14px 14px 12px;
+  cursor:pointer;
+  font-family: 'Sofia Sans Condensed';
+  transition: 120ms ease;
+  background:#fff;
+}
+
+.card:hover{
+  transform: translateY(-1px);
+  box-shadow: 0 8px 26px rgba(0,0,0,0.08);
+}
+
+.card.active{
+  border-color: rgba(128,0,255,0.45);
+  box-shadow: 0 10px 30px rgba(128,0,255,0.12);
+}
+
+.cardTop{
+  display:flex;
+  align-items:center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.cardTitle{
+  font-family: 'Sofia Sans Condensed';
+  font-size: 22px;
+  font-weight: 800;
+  display:flex;
+  align-items:center;
+  gap: 8px;
+}
+
+.unreadDot{
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #7b2cff;
+}
+
+.badge{
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(0,0,0,0.15);
+  opacity: .9;
+}
+
+.badgeUnread{
+  border-color: rgba(123,44,255,0.45);
+}
+
+.meta{
+  margin-top: 4px;
+  font-size: 12px;
+  opacity: .75;
+}
+
+.snippet{
+  margin-top: 10px;
+  font-size: 14px;
+  opacity: .85;
+  white-space: nowrap;
+  overflow:hidden;
+  text-overflow: ellipsis;
+}
+
+.emptyLeft{
+  padding: 12px 6px;
+  opacity: .7;
+}
+
+.right{
+  flex: 1;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding: 18px;
+}
+
+.placeholder{
+  text-align:center;
+  font-family: 'Sofia Sans Condensed';
+  opacity: .75;
+  max-width: 420px;
+}
+
+.phIcon{
+  font-size: 42px;
+  width: 42px;
+  height: 42px;
+  margin-bottom: 10px;
+}
+
+.preview{
+  width: min(760px, 95%);
+  border: 1px solid rgba(0,0,0,0.08);
+  border-radius: 18px;
+  padding: 18px;
+  box-shadow: 0 14px 40px rgba(0,0,0,0.06);
+  font-family: 'Sofia Sans Condensed';
+}
+
+.previewHeader{
+  display:flex;
+  align-items:flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(0,0,0,0.08);
+  font-family: 'Sofia Sans Condensed';
+  margin-bottom: 12px;
+}
+
+.previewTitle{
+  display:flex;
+  align-items:flex-start;
+  font-family: 'Sofia Sans Condensed';
+  gap: 10px;
+}
+
+.previewTitle h2{
+  margin: 0;
+  font-family: 'Sofia Sans Condensed';
+  font-weight: 900;
+  font-size: 28px;
+}
+
+.previewTitle p{
+  margin: 2px 0 0 0;
+  opacity: .75;
+}
+
+.readPill{
+  font-size: 12px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(0,0,0,0.15);
+}
+
+.readPillUnread{
+  border-color: rgba(123,44,255,0.45);
+}
+
+.previewBody{
+  font-size: 16px;
+  line-height: 1.45;
+  opacity: .9;
+  white-space: pre-wrap;
+}

--- a/frontend/Gorki/src/app/notification-inbox/notification-inbox.html
+++ b/frontend/Gorki/src/app/notification-inbox/notification-inbox.html
@@ -1,0 +1,91 @@
+<div class="page">
+  <!-- LEFT: Inbox -->
+  <aside class="left">
+    <div class="top">
+      <div class="title">
+        <mat-icon class="titleIcon">notifications</mat-icon>
+        <span>Inbox</span>
+      </div>
+
+      <div class="status">
+        <span class="dot"></span>
+        <span>Connected</span>
+      </div>
+    </div>
+
+    <button class="refreshBtn" mat-stroked-button (click)="refresh()">
+      <mat-icon>refresh</mat-icon>
+      Refresh
+    </button>
+
+    <div class="list">
+      <div *ngIf="loading" class="loading">
+        <mat-spinner diameter="26"></mat-spinner>
+        <span>Loading...</span>
+      </div>
+
+      <div
+        *ngFor="let n of items; trackBy: trackById"
+        class="card"
+        [class.active]="selected?.id === n.id"
+        (click)="select(n)"
+      >
+        <div class="cardTop">
+          <div class="cardTitle">
+            <span class="unreadDot" *ngIf="!n.read"></span>
+            {{ n.purpose || 'Notification' }}
+          </div>
+
+          <div class="badge" [class.badgeUnread]="!n.read">
+            {{ n.read ? 'Read' : 'New' }}
+          </div>
+        </div>
+
+        <div class="meta">
+          <span class="metaText">{{ formatTime(n.createdAt) }}</span>
+        </div>
+
+        <div class="snippet">
+          {{ n.content || 'No content' }}
+        </div>
+      </div>
+
+      <div *ngIf="!loading && items.length === 0" class="emptyLeft">
+        No notifications yet.
+      </div>
+    </div>
+  </aside>
+
+  <!-- RIGHT: Preview -->
+  <main class="right">
+    <ng-container *ngIf="selected; else placeholder">
+      <div class="preview">
+        <div class="previewHeader">
+          <div class="previewTitle">
+            <mat-icon>campaign</mat-icon>
+            <div>
+              <h2>{{ selected.purpose || 'Notification' }}</h2>
+              <p>{{ formatTime(selected.createdAt) }}</p>
+            </div>
+          </div>
+
+          <div class="readPill" [class.readPillUnread]="!selected.read">
+            {{ selected.read ? 'Read' : 'New' }}
+          </div>
+        </div>
+
+        <div class="previewBody">
+          {{ selected.content }}
+        </div>
+      </div>
+    </ng-container>
+
+    <ng-template #placeholder>
+      <div class="placeholder">
+        <mat-icon class="phIcon">notifications_none</mat-icon>
+        <h2>Select a notification</h2>
+        <p>Pick a notification from the inbox to view details.</p>
+      </div>
+    </ng-template>
+  </main>
+</div>

--- a/frontend/Gorki/src/app/notification-inbox/notification-inbox.spec.ts
+++ b/frontend/Gorki/src/app/notification-inbox/notification-inbox.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NotificationInbox } from './notification-inbox';
+
+describe('NotificationInbox', () => {
+  let component: NotificationInbox;
+  let fixture: ComponentFixture<NotificationInbox>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NotificationInbox]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(NotificationInbox);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/Gorki/src/app/notification-inbox/notification-inbox.ts
+++ b/frontend/Gorki/src/app/notification-inbox/notification-inbox.ts
@@ -1,0 +1,104 @@
+import { Component, OnDestroy, OnInit, AfterViewInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subscription, finalize } from 'rxjs';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+import { NotificationDTO } from '../model/ui/notification-dto';
+import { NotificationService } from '../service/notification-service';
+import { AuthService } from '../infrastructure/auth.service';
+
+@Component({
+  selector: 'app-notification-inbox',
+  standalone: true,
+  imports: [CommonModule, MatIconModule, MatButtonModule, MatProgressSpinnerModule],
+  templateUrl: './notification-inbox.html',
+  styleUrls: ['./notification-inbox.css'],
+})
+export class NotificationInbox implements OnInit, AfterViewInit, OnDestroy {
+  loading = false;
+
+  userId!: number;
+  items: NotificationDTO[] = [];
+  selected?: NotificationDTO;
+
+  private subLoad?: Subscription;
+  private subMark?: Subscription;
+
+  constructor(
+    private notificationService: NotificationService,
+    private authService: AuthService
+  ) {}
+
+  ngOnInit(): void {
+    const id = this.authService.getId();
+    if (!id) {
+      console.error('No userId found for notifications inbox.');
+      return;
+    }
+    this.userId = Number(id);
+  }
+
+  ngAfterViewInit(): void {
+    // bitno: tek posle prvog rendera dialoga
+    setTimeout(() => this.refresh(), 0);
+  }
+
+  ngOnDestroy(): void {
+    this.subLoad?.unsubscribe();
+    this.subMark?.unsubscribe();
+  }
+
+  refresh(): void {
+    if (!this.userId) return;
+
+    this.subLoad?.unsubscribe();
+
+    // async boundary da se ne desi promena u istom CD ciklusu
+    setTimeout(() => {
+      this.loading = true;
+
+      this.subLoad = this.notificationService
+        .getAllForUser(this.userId)
+        .pipe(finalize(() => (this.loading = false)))
+        .subscribe({
+          next: (list) => {
+            this.items = (list ?? []).slice().sort(
+              (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+            );
+
+            if (this.selected) {
+              this.selected =
+                this.items.find(x => x.id === this.selected!.id) ?? this.selected;
+            }
+          },
+          error: (err) => console.error('Failed to load notifications:', err),
+        });
+    }, 0);
+  }
+
+  select(n: NotificationDTO): void {
+    this.selected = n;
+
+    if (n.read) return;
+
+    // immutable update
+    this.items = this.items.map(x => (x.id === n.id ? { ...x, read: true } : x));
+    this.selected = { ...n, read: true };
+
+    this.subMark?.unsubscribe();
+    this.subMark = this.notificationService.markAsRead(n.id, this.userId).subscribe({
+      next: () => {},
+      error: (err) => console.error('markAsRead failed:', err),
+    });
+  }
+
+  trackById(_: number, n: NotificationDTO) {
+    return n.id;
+  }
+
+  formatTime(iso: string): string {
+    try { return new Date(iso).toLocaleString(); } catch { return iso; }
+  }
+}

--- a/frontend/Gorki/src/app/rides/end-of-ride-panel/end-of-ride-panel.ts
+++ b/frontend/Gorki/src/app/rides/end-of-ride-panel/end-of-ride-panel.ts
@@ -7,7 +7,7 @@ import { FinishRideDto } from '../../model/ui/finish-ride-dto';
 import { EndRideService } from '../../service/end-ride-service';
 import { AuthService } from '../../infrastructure/auth.service';
 import { DriverRideInProgress} from '../../service/driver-ride-in-progress';
-import { RideInProgressDTO } from '../../model/ui/ride-in-progress-dto';
+import { ChangeDetectorRef } from '@angular/core';
 
 @Component({
   selector: 'app-end-of-ride-panel',
@@ -39,7 +39,8 @@ export class EndOfRidePanel {
     private router: Router,
     private rideService: EndRideService,
     private authService:AuthService,
-    private driverService:DriverRideInProgress
+    private driverService:DriverRideInProgress,
+    private cdr:ChangeDetectorRef
   ) {}
 
   newRides: DriverScheduledRide[] = [];
@@ -77,6 +78,7 @@ export class EndOfRidePanel {
   }
   openModal() {
     this.isModalOpen = true;
+    this.cdr.detectChanges();
   }
 
   closeModal() {
@@ -87,12 +89,12 @@ export class EndOfRidePanel {
     console.log('START RIDE');
     this.closeModal();
     this.router.navigateByUrl('HomePage');
-    //ucitavanje novih podataka
+
   }
 
   goToScheduledRides() {
     console.log('GO TO SCHEDULED RIDES');
-    this.router.navigateByUrl('driver-sceduled-rides');
+    this.router.navigateByUrl('scheduled-rides');
     this.closeModal();
   }
   

--- a/frontend/Gorki/src/app/rides/rides-list-user/rides-list-user.ts
+++ b/frontend/Gorki/src/app/rides/rides-list-user/rides-list-user.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ElementRef } from '@angular/core';
+import { Component, ViewChild, ElementRef, ChangeDetectorRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { DateFilter } from '../filters/date-filter/date-filter';
@@ -9,6 +9,7 @@ import { RatingPanel } from "../rating-panel/rating-panel";
 import { RatingService } from '../../service/rating-service';
 import { PassengerHistoryService } from '../../service/passenger-history-service';
 import { AuthService } from '../../infrastructure/auth.service';
+
 
 @Component({
   selector: 'app-rides-list-user',
@@ -26,7 +27,8 @@ export class RidesListUser {
     private passengerHistoryService: PassengerHistoryService,
     private router: Router, 
     private ratingService: RatingService,
-    private authService:AuthService) {}
+    private authService:AuthService,
+    private cdr:ChangeDetectorRef) {}
 
   filteredRides:UserHistoryRide[]=[];
   allRides:UserHistoryRide[]=[];
@@ -153,6 +155,7 @@ export class RidesListUser {
 
         this.showRating = false;
         this.selectedRideForRating = null;
+        this.cdr.detectChanges();
       },
       error: (err) => {
         console.error("Greska pri ocenjivanju", err);

--- a/frontend/Gorki/src/app/service/notification-service.spec.ts
+++ b/frontend/Gorki/src/app/service/notification-service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { NotificationService } from './notification-service';
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NotificationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/Gorki/src/app/service/notification-service.ts
+++ b/frontend/Gorki/src/app/service/notification-service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../env/environment';
+import { NotificationDTO } from '../model/ui/notification-dto';
+
+@Injectable({ providedIn: 'root' })
+export class NotificationService {
+  private api = environment.apiHost;
+
+  constructor(private http: HttpClient) {}
+
+  getAllForUser(userId: number): Observable<NotificationDTO[]> {
+    return this.http.get<NotificationDTO[]>(`${this.api}/notifications/user/${userId}`);
+  }
+
+  markAsRead(notificationId: number, userId: number): Observable<void> {
+    return this.http.put<void>(`${this.api}/notifications/${notificationId}/read/${userId}`, {});
+  }
+}


### PR DESCRIPTION
When the ride is accepted, and the driver is assigned to created ride, all linked passengers get an email and app notification that they are added to new ride. By clicking on link in email or notification they can track that ride. Implemented frontend part for this functionality, all notifications are shown in notification inbox.