### PR TITLE
Implement ordering from favourite routes for mobile app (closes #222)

### DIFF
--- a/mobile/app/src/main/java/ftn/mrs_team11_gorki/adapter/FavouriteRoutesAdapter.java
+++ b/mobile/app/src/main/java/ftn/mrs_team11_gorki/adapter/FavouriteRoutesAdapter.java
@@ -1,0 +1,167 @@
+package ftn.mrs_team11_gorki.adapter;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.Button;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ftn.mrs_team11_gorki.R;
+import ftn.mrs_team11_gorki.dto.GetRouteDTO;
+import ftn.mrs_team11_gorki.dto.LocationDTO;
+
+public class FavouriteRoutesAdapter extends BaseAdapter {
+
+    public interface Listener {
+        void onRemoveClicked(@NonNull GetRouteDTO route);
+        void onChooseClicked(@NonNull GetRouteDTO route);
+    }
+
+    private final Context context;
+    private final Listener listener;
+    private final List<GetRouteDTO> routes = new ArrayList<>();
+
+    public FavouriteRoutesAdapter(@NonNull Context context, @NonNull Listener listener) {
+        this.context = context;
+        this.listener = listener;
+    }
+
+    public void submitList(@NonNull List<GetRouteDTO> newItems) {
+        routes.clear();
+        routes.addAll(newItems);
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public int getCount() {
+        return routes.size();
+    }
+
+    @Override
+    public GetRouteDTO getItem(int position) {
+        return routes.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        GetRouteDTO dto = getItem(position);
+        return dto.getId() != null ? dto.getId() : position;
+    }
+
+    static class VH {
+        TextView routeNo;
+        TextView startingPointLabel;
+        TextView destinationLabel;
+        ListView stoppingPointsList;
+        Button btnRemoveFromFav;
+        Button btnChoose;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        VH h;
+        if (convertView == null) {
+            convertView = LayoutInflater.from(context).inflate(R.layout.route_card, parent, false);
+            h = new VH();
+            h.routeNo = convertView.findViewById(R.id.routeNo);
+            h.startingPointLabel = convertView.findViewById(R.id.startingPointLabel);
+            h.destinationLabel = convertView.findViewById(R.id.destinationLabel);
+            h.stoppingPointsList = convertView.findViewById(R.id.stoppingPointsList);
+            h.btnRemoveFromFav = convertView.findViewById(R.id.btnRemoveFromFav);
+            h.btnChoose = convertView.findViewById(R.id.btnChoose);
+            convertView.setTag(h);
+        } else {
+            h = (VH) convertView.getTag();
+        }
+
+        GetRouteDTO route = getItem(position);
+
+        // Title
+        h.routeNo.setText("Route #" + (position + 1));
+
+        // Locations -> start / end / stops
+        List<LocationDTO> locs = route.getLocations();
+        String start = "";
+        String end = "";
+        List<String> stops = new ArrayList<>();
+
+        if (locs != null && !locs.isEmpty()) {
+            start = safeAddress(locs.get(0));
+            end = safeAddress(locs.get(locs.size() - 1));
+
+            // between start and end
+            for (int i = 1; i < locs.size() - 1; i++) {
+                String addr = safeAddress(locs.get(i));
+                if (addr != null) {
+                    addr = addr.trim();
+                    if (!addr.isEmpty()) {
+                        stops.add(addr);
+                    }
+                }
+            }
+        }
+
+        h.startingPointLabel.setText(context.getString(R.string.startingPoint) + ": " + start);
+        h.destinationLabel.setText(context.getString(R.string.destination) + ": " + end);
+
+        // Stops list inside card
+        StoppingPointsAdapter spAdapter = new StoppingPointsAdapter(context, stops);
+        h.stoppingPointsList.setAdapter(spAdapter);
+
+        // (Optional) If nested list height becomes 1 row only, uncomment this:
+        h.stoppingPointsList.post(() -> setListViewHeightBasedOnChildren(h.stoppingPointsList));
+
+        h.btnRemoveFromFav.setOnClickListener(v -> listener.onRemoveClicked(route));
+        h.btnChoose.setOnClickListener(v -> listener.onChooseClicked(route));
+
+        return convertView;
+    }
+
+    private String safeAddress(LocationDTO loc) {
+        if (loc == null) return "";
+        // PROMENI ako ti nije getAddress()
+        String a = loc.getAddress();
+        return a != null ? a : "";
+    }
+
+    // Ako ti nested ListView ne prikazuje sve stavke, koristi ovu helper metodu:
+    @SuppressWarnings("unused")
+    private void setListViewHeightBasedOnChildren(ListView listView) {
+        android.widget.ListAdapter listAdapter = listView.getAdapter();
+        if (listAdapter == null) return;
+
+        int totalHeight = 0;
+        int items = 0;
+
+        int width = listView.getWidth();
+        if (width <= 0) {
+            // fallback: pola ekrana je dovoljno jer je u horizontal layout-u
+            width = listView.getResources().getDisplayMetrics().widthPixels / 2;
+        }
+        int widthSpec = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.AT_MOST);
+
+        for (int i = 0; i < listAdapter.getCount(); i++) {
+            Object item = listAdapter.getItem(i);
+            if (item instanceof String && ((String) item).trim().isEmpty()) continue;
+
+            View listItem = listAdapter.getView(i, null, listView);
+            listItem.measure(widthSpec, View.MeasureSpec.UNSPECIFIED);
+            totalHeight += listItem.getMeasuredHeight();
+            items++;
+        }
+
+        ViewGroup.LayoutParams params = listView.getLayoutParams();
+        params.height = (items == 0) ? 0 : totalHeight; // bez divider-a
+        listView.setLayoutParams(params);
+        listView.requestLayout();
+    }
+
+}

--- a/mobile/app/src/main/java/ftn/mrs_team11_gorki/adapter/StoppingPointsAdapter.java
+++ b/mobile/app/src/main/java/ftn/mrs_team11_gorki/adapter/StoppingPointsAdapter.java
@@ -1,0 +1,36 @@
+package ftn.mrs_team11_gorki.adapter;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+import ftn.mrs_team11_gorki.R;
+
+public class StoppingPointsAdapter extends ArrayAdapter<String> {
+
+    public StoppingPointsAdapter(@NonNull Context context, @NonNull List<String> items) {
+        super(context, 0, items);
+    }
+
+    @NonNull
+    @Override
+    public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        View v = convertView;
+        if (v == null) {
+            v = LayoutInflater.from(getContext()).inflate(R.layout.stopping_point_label, parent, false);
+        }
+
+        TextView tv = (TextView) v;
+        String item = getItem(position);
+        tv.setText(item != null ? item : "");
+        return v;
+    }
+}

--- a/mobile/app/src/main/java/ftn/mrs_team11_gorki/service/PassengerService.java
+++ b/mobile/app/src/main/java/ftn/mrs_team11_gorki/service/PassengerService.java
@@ -1,12 +1,15 @@
 package ftn.mrs_team11_gorki.service;
 
+import java.util.Collection;
 import java.util.List;
 
 import ftn.mrs_team11_gorki.dto.DriverRideHistoryDTO;
+import ftn.mrs_team11_gorki.dto.GetRouteDTO;
 import ftn.mrs_team11_gorki.dto.InconsistencyRequestDTO;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
+import retrofit2.http.DELETE;
 import retrofit2.http.GET;
 import retrofit2.http.Header;
 import retrofit2.http.POST;
@@ -31,4 +34,13 @@ public interface PassengerService {
             @Path("rideId") long rideId,
             @Body InconsistencyRequestDTO body
     );
+
+    @GET("api/passengers/{id}/favourite-routes")
+    Call<Collection<GetRouteDTO>> getFavouriteRoutes(@Path("id") Long id);
+
+    @POST("api/passengers/{id}/favourite-routes/{rideId}")
+    Call<GetRouteDTO> addFavouriteRoute(@Path("id") Long id, @Path("rideId") Long rideId);
+
+    @DELETE("api/passengers/{id}/favourite-routes/{routeId}")
+    Call<Void> deleteFavouriteRoute(@Path("id") Long id, @Path("routeId") Long routeId);
 }

--- a/mobile/app/src/main/java/ftn/mrs_team11_gorki/view/FavouriteRouteViewModel.java
+++ b/mobile/app/src/main/java/ftn/mrs_team11_gorki/view/FavouriteRouteViewModel.java
@@ -1,0 +1,87 @@
+package ftn.mrs_team11_gorki.view;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import ftn.mrs_team11_gorki.dto.GetRouteDTO;
+import ftn.mrs_team11_gorki.service.PassengerService;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class FavouriteRouteViewModel extends ViewModel {
+
+    private final PassengerService passengerService;
+
+    private final MutableLiveData<List<GetRouteDTO>> routes = new MutableLiveData<>(new ArrayList<>());
+    private final MutableLiveData<Boolean> loading = new MutableLiveData<>(false);
+    private final MutableLiveData<String> error = new MutableLiveData<>(null);
+
+    public FavouriteRouteViewModel(@NonNull PassengerService passengerService) {
+        this.passengerService = passengerService;
+    }
+
+    public LiveData<List<GetRouteDTO>> getRoutes() { return routes; }
+    public LiveData<Boolean> getLoading() { return loading; }
+    public LiveData<String> getError() { return error; }
+
+    public void loadFavouriteRoutes(long passengerId) {
+        loading.setValue(true);
+        error.setValue(null);
+
+        passengerService.getFavouriteRoutes(passengerId).enqueue(new Callback<Collection<GetRouteDTO>>() {
+            @Override
+            public void onResponse(@NonNull Call<Collection<GetRouteDTO>> call,
+                                   @NonNull Response<Collection<GetRouteDTO>> response) {
+                loading.setValue(false);
+                if (response.isSuccessful() && response.body() != null) {
+                    routes.setValue(new ArrayList<>(response.body()));
+                } else {
+                    error.setValue("Failed to load favourite routes.");
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<Collection<GetRouteDTO>> call, @NonNull Throwable t) {
+                loading.setValue(false);
+                error.setValue(t.getMessage() != null ? t.getMessage() : "Network error.");
+            }
+        });
+    }
+
+    public void deleteFavouriteRoute(long passengerId, long routeId) {
+        loading.setValue(true);
+        error.setValue(null);
+
+        passengerService.deleteFavouriteRoute(passengerId, routeId).enqueue(new Callback<Void>() {
+            @Override
+            public void onResponse(@NonNull Call<Void> call, @NonNull Response<Void> response) {
+                loading.setValue(false);
+                if (response.isSuccessful()) {
+                    List<GetRouteDTO> current = routes.getValue();
+                    if (current == null) current = new ArrayList<>();
+
+                    List<GetRouteDTO> updated = new ArrayList<>();
+                    for (GetRouteDTO r : current) {
+                        if (r.getId() == null || r.getId() != routeId) updated.add(r);
+                    }
+                    routes.setValue(updated);
+                } else {
+                    error.setValue("Failed to remove route from favourites.");
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<Void> call, @NonNull Throwable t) {
+                loading.setValue(false);
+                error.setValue(t.getMessage() != null ? t.getMessage() : "Network error.");
+            }
+        });
+    }
+}

--- a/mobile/app/src/main/java/ftn/mrs_team11_gorki/view/FavouriteRouteViewModelFactory.java
+++ b/mobile/app/src/main/java/ftn/mrs_team11_gorki/view/FavouriteRouteViewModelFactory.java
@@ -1,0 +1,26 @@
+package ftn.mrs_team11_gorki.view;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+
+import ftn.mrs_team11_gorki.service.PassengerService;
+
+public class FavouriteRouteViewModelFactory implements ViewModelProvider.Factory {
+
+    private final PassengerService passengerService;
+
+    public FavouriteRouteViewModelFactory(PassengerService passengerService) {
+        this.passengerService = passengerService;
+    }
+
+    @NonNull
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
+        if (modelClass.isAssignableFrom(FavouriteRouteViewModel.class)) {
+            return (T) new FavouriteRouteViewModel(passengerService);
+        }
+        throw new IllegalArgumentException("Unknown ViewModel class");
+    }
+}

--- a/mobile/app/src/main/res/layout/fragment_driver_registration.xml
+++ b/mobile/app/src/main/res/layout/fragment_driver_registration.xml
@@ -10,6 +10,5 @@
         layout="@layout/driver_registration_form"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom"
         android:layout_margin="24dp"/>
 </FrameLayout>

--- a/mobile/app/src/main/res/layout/fragment_favourite_route.xml
+++ b/mobile/app/src/main/res/layout/fragment_favourite_route.xml
@@ -10,6 +10,9 @@
         android:id="@+id/favouriteRoutesList"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_margin="30dp"
+        android:divider="@android:color/transparent"
+        android:dividerHeight="16dp"
         tools:listitem="@layout/route_card" />
 
 </FrameLayout>

--- a/mobile/app/src/main/res/layout/route_card.xml
+++ b/mobile/app/src/main/res/layout/route_card.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_gravity="center"
+    android:layout_marginVertical="8dp"
     style="@style/cardStyle">
 
     <TextView
@@ -53,7 +53,6 @@
         android:gravity="center">
 
         <TextView
-            android:id="@+id/txtPrice"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/stoppingPointsCard"
@@ -62,7 +61,9 @@
         <ListView
             android:id="@+id/stoppingPointsList"
             android:layout_width="wrap_content"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
+            android:divider="@null"
+            android:dividerHeight="0dp"
             tools:listitem="@layout/stopping_point_label" />
 
     </LinearLayout>

--- a/mobile/app/src/main/res/menu/drawer_passenger.xml
+++ b/mobile/app/src/main/res/menu/drawer_passenger.xml
@@ -30,8 +30,4 @@
         android:title="Logout"
         android:icon="@drawable/ic_logout"/>
 
-    <item
-        android:id="@+id/favouriteRouteFragment"
-        android:title="Favourite Routes"
-        android:icon="@drawable/ic_vehicle"/>
 </menu>

--- a/mobile/app/src/main/res/navigation/base_navigation.xml
+++ b/mobile/app/src/main/res/navigation/base_navigation.xml
@@ -41,6 +41,11 @@
         app:popUpTo="@id/passengerHomeFragment"
         tools:layout="@layout/fragment_ride_ordering"/>
     <fragment
+        android:id="@+id/favouriteRouteFragment"
+        android:name="ftn.mrs_team11_gorki.fragments.FavouriteRouteFragment"
+        app:popUpTo="@id/rideOrderingFragment"
+        tools:layout="@layout/fragment_favourite_route"/>
+    <fragment
         android:id="@+id/profileInfoFragment"
         android:name="ftn.mrs_team11_gorki.fragments.ProfileInfoFragment"
         app:popUpTo="@id/homeFragment"

--- a/mobile/app/src/main/res/values/themes.xml
+++ b/mobile/app/src/main/res/values/themes.xml
@@ -123,7 +123,6 @@
         <item name="android:padding">16dp</item>
         <item name="android:orientation">vertical</item>
         <item name="android:background">@drawable/container_bg</item>
-        <item name="android:layout_marginVertical">16dp</item>
     </style>
     <style name="cardLabel">
         <item name="android:textSize">18sp</item>


### PR DESCRIPTION
While ordering a ride, the user should be able to view and quickly select one of their favorite routes. When a favorite route is selected, the starting location, destination, and all intermediate stops should be automatically prefilled in the ride ordering form.

Additionally, on the Ride History screen, the user should be able to add a route to favorites or remove it from favorites.